### PR TITLE
use tostring to print

### DIFF
--- a/simple_test-0.0.5-0.rockspec
+++ b/simple_test-0.0.5-0.rockspec
@@ -1,9 +1,9 @@
 package = 'simple_test'
-version = '0.0.4-0'
+version = '0.0.5-0'
 
 source = {
   url = 'git://github.com/evandrolg/simple_test.git',
-  tag = 'v0.0.4'
+  tag = 'v0.0.5'
 }
 
 description = {

--- a/simple_test.lua
+++ b/simple_test.lua
@@ -13,7 +13,8 @@ local colors = {
 local assertions = {
   equal = function(a, b, msg)
     local message = msg or format('%s%s%s expected but was %s%s%s',
-          colors.green[1], a, colors.green[2], colors.red[1], b, colors.red[2])
+          colors.green[1], tostring(a), colors.green[2],
+          colors.red[1], tostring(b), colors.red[2])
 
     assert(a == b, message)
   end,


### PR DESCRIPTION
checking non-string values with equal() have been failing (found this out by running array.lua's tests).

Ran `lua test.lua` and passing.