### PR TITLE
fix assert.throw pattern match

### DIFF
--- a/src/simple_test/assertions.lua
+++ b/src/simple_test/assertions.lua
@@ -26,17 +26,24 @@ local assertions = {
     assert(not a, message)
   end,
 
-  throw = function(method, params, raised_message, msg)
-    local raised_error = false
+  throw = function(method, params, raised_pattern, msg)
+    local raised_error = nil
+    local matched = false
 
     xpcall(function()
       method(table.unpack(params))
     end, function(err)
-      raised_error = true
-      assert(string.find(err, raised_message))
+      raised_error = err
+      if not raised_pattern or string.find(err, raised_pattern) then
+        matched = true
+      end
     end)
 
     if not raised_error then error(msg or 'should throw error') end
+    if not matched then
+      error(format("threw error '%s' but did not contain pattern '%s'",
+            raised_error, raised_pattern))
+    end
   end,
 
   delta = function(a, b, delta, msg)

--- a/src/simple_test/init.lua
+++ b/src/simple_test/init.lua
@@ -2,13 +2,18 @@ local assertions = require 'simple_test.assertions'
 local colors = require 'simple_test.colors'
 local format = string.format
 
-local function test(name, callback)
+local function test(name, callback, expect_to_fail)
   xpcall(function()
     callback(assertions)
     print(format('%s[pass]%s %s', colors.green[1], colors.green[2], name))
   end, function(err)
-    print(format('%s[fail]%s %s : %s', colors.red[1], colors.red[2], name, err))
-    os.exit(1)
+    if not expect_to_fail then
+      print(format('%s[fail]%s %s : %s', colors.red[1], colors.red[2], name, err))
+      os.exit(1)
+    else
+      print(format('%s[failed successfully!]%s %s : %s',
+            colors.green[1], colors.green[2], name, err))
+    end
   end)
 end
 

--- a/src/simple_test/init.lua
+++ b/src/simple_test/init.lua
@@ -10,6 +10,7 @@ local function test(name, callback, expect_to_fail)
     else
       print(format('%s[passed unsuccessfully...]%s %s',
             colors.red[1], colors.red[2], name))
+      os.exit(1)
     end
   end, function(err)
     if not expect_to_fail then

--- a/src/simple_test/init.lua
+++ b/src/simple_test/init.lua
@@ -5,7 +5,12 @@ local format = string.format
 local function test(name, callback, expect_to_fail)
   xpcall(function()
     callback(assertions)
-    print(format('%s[pass]%s %s', colors.green[1], colors.green[2], name))
+    if not expect_to_fail then
+      print(format('%s[pass]%s %s', colors.green[1], colors.green[2], name))
+    else
+      print(format('%s[passed unsuccessfully...]%s %s',
+            colors.red[1], colors.red[2], name))
+    end
   end, function(err)
     if not expect_to_fail then
       print(format('%s[fail]%s %s : %s', colors.red[1], colors.red[2], name, err))

--- a/test.lua
+++ b/test.lua
@@ -35,6 +35,26 @@ test('assert.throw (with pattern)', function(a)
   a.throw(method, { 'a', 'b' }, 'invalid!')
 end)
 
+test('assert.throw (pattern not matched)', function(a)
+  local method = function(a, b)
+    assert(a == b, 'invalid!')
+  end
+
+  a.throw(method, { 'a', 'b' }, 'foo')
+end, true)
+
+test('assert.throw (does not throw)', function(a)
+  local method = function(a, b) end
+
+  a.throw(method, { 'a', 'b' })
+end, true)
+
+test('assert.throw (does not throw but still has pattern arg)', function(a)
+  local method = function(a, b) end
+
+  a.throw(method, { 'a', 'b' }, "foo")
+end, true)
+
 test('assert.delta', function(a)
   a.delta(0.3, 0.1 + 0.2)
 end)
@@ -71,25 +91,3 @@ test('utils.is_deep_equal', function(a)
   a.ok(is_deep_equal({ 'a', 'b', 'c', 'd' }, { 'a', 'b', 'c', 'd' }))
   a.not_ok(is_deep_equal({ 'a', 'b', 'c', 'd' }, { 'a', 'b', 'c', 'e' }))
 end)
-
--- the following tests are expected to fail
-
-test('assert.throw (pattern not matched)', function(a)
-  local method = function(a, b)
-    assert(a == b, 'invalid!')
-  end
-
-  a.throw(method, { 'a', 'b' }, 'foo')
-end, true)
-
-test('assert.throw (does not throw)', function(a)
-  local method = function(a, b) end
-
-  a.throw(method, { 'a', 'b' })
-end, true)
-
-test('assert.throw (does not throw but still has pattern arg)', function(a)
-  local method = function(a, b) end
-
-  a.throw(method, { 'a', 'b' }, "foo")
-end, true)

--- a/test.lua
+++ b/test.lua
@@ -19,7 +19,15 @@ test('assert.not_ok', function(a)
   a.not_ok(nil)
 end)
 
-test('assert.throw', function(a)
+test('assert.throw (no pattern)', function(a)
+  local method = function(a, b)
+    assert(a == b, 'invalid!')
+  end
+
+  a.throw(method, { 'a', 'b' })
+end)
+
+test('assert.throw (with pattern)', function(a)
   local method = function(a, b)
     assert(a == b, 'invalid!')
   end
@@ -63,3 +71,25 @@ test('utils.is_deep_equal', function(a)
   a.ok(is_deep_equal({ 'a', 'b', 'c', 'd' }, { 'a', 'b', 'c', 'd' }))
   a.not_ok(is_deep_equal({ 'a', 'b', 'c', 'd' }, { 'a', 'b', 'c', 'e' }))
 end)
+
+-- the following tests are expected to fail
+
+test('assert.throw (pattern not matched)', function(a)
+  local method = function(a, b)
+    assert(a == b, 'invalid!')
+  end
+
+  a.throw(method, { 'a', 'b' }, 'foo')
+end, true)
+
+test('assert.throw (does not throw)', function(a)
+  local method = function(a, b) end
+
+  a.throw(method, { 'a', 'b' })
+end, true)
+
+test('assert.throw (does not throw but still has pattern arg)', function(a)
+  local method = function(a, b) end
+
+  a.throw(method, { 'a', 'b' }, "foo")
+end, true)


### PR DESCRIPTION
`assert.throw` will succeed even if the pattern is not matched, because it uses a raw `assert` which throws its own error, which *also* gets caught. this is a simple fix and some tests for that.