### PR TITLE
handle reference cycles in `is_deep_equal` to avoid stack overflow

### DIFF
--- a/simple_test-1.0.1-0.rockspec
+++ b/simple_test-1.0.1-0.rockspec
@@ -1,9 +1,9 @@
 package = 'simple_test'
-version = '1.0.1-0'
+version = '1.0.2-0'
 
 source = {
   url = 'git://github.com/evandrolg/simple_test.git',
-  tag = 'v1.0.1'
+  tag = 'v1.0.2'
 }
 
 description = {

--- a/src/simple_test/utils.lua
+++ b/src/simple_test/utils.lua
@@ -2,18 +2,28 @@ function is_table(obj)
   return type(obj) == 'table'
 end
 
-function is_deep_equal(a, b)
+local function is_deep_equal_helper(a, b, table_pairs)
   if is_table(a) and is_table(b) then
     if (#a ~= #b) then return false end
 
+    if table_pairs[a] == b then
+      return true
+    end
+
+    table_pairs[a] = b
+
     for k in pairs(a) do
-      if not is_deep_equal(a[k], b[k]) then return false end
+      if not is_deep_equal_helper(a[k], b[k], table_pairs) then return false end
     end
 
     return true
   end
 
   return a == b
+end
+
+function is_deep_equal(a, b)
+  return is_deep_equal_helper(a, b, {})
 end
 
 return {

--- a/test.lua
+++ b/test.lua
@@ -91,3 +91,49 @@ test('utils.is_deep_equal', function(a)
   a.ok(is_deep_equal({ 'a', 'b', 'c', 'd' }, { 'a', 'b', 'c', 'd' }))
   a.not_ok(is_deep_equal({ 'a', 'b', 'c', 'd' }, { 'a', 'b', 'c', 'e' }))
 end)
+
+test('utils.is_deep_equal (reference cycles, different graph shape)', function(a)
+  -- structurally equivalent but nested table t is referenced twice in obj1,
+  -- but copied in obj2
+  local t = { d = "foo" }
+
+  local obj1 = {
+    a = { c = t },
+    b = t
+  }
+
+  local obj2 = {
+    a = { c = { d = "foo" } },
+    b = { d = "foo" }
+  }
+
+  a.ok(is_deep_equal(obj1, obj2))
+end)
+
+test("utils.is_deep_equal (reference cycles, same graph shape)", function(a)
+  -- tables both contain a self reference to the starting table. they are completely
+  -- separated graphs
+  local table_a1 = {}
+  local table_b1 = {}
+  table_a1.b = table_b1
+  table_b1.a = table_a1
+
+  local table_a2 = {}
+  local table_b2 = {}
+  table_a2.b = table_b2
+  table_b2.a = table_a2
+
+  a.ok(is_deep_equal(table_a1, table_a2))
+end)
+
+test("utils.is_deep_equal (reference cycles, connected graphs)", function(a)
+  -- tables form a simple reference cycle and are part of the same connected
+  -- graph. because it is a symmetrical graph, they are still structurally
+  -- equivalent
+  local table_a = {}
+  local table_b = {}
+  table_a.ref = table_b
+  table_b.ref = table_a
+
+  a.ok(is_deep_equal(table_a, table_b))
+end)


### PR DESCRIPTION
i was scratching my head, thinking if it's just a "garbage in, garbage out" situation and it's best to ignore it. but i looked at some other assertion frameworks to see if they handle this sort of thing, and they typically do. since the code changes are minimal, and the extra memory it uses to keep track of visited tables is bounded by the size of the tables being compared, i feel like it's worth it.

the first test i added actually passes in the original `is_deep_equal` implementation, but i thought it is just a good test to have. the last two tests would go into infinite recursion without this fix.